### PR TITLE
fix: Correct paths in Dockerfiles for build context

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -5,13 +5,16 @@ FROM python:3.9-slim
 WORKDIR /app
 
 # Copy the requirements file into the container at /app
-COPY ./requirements.txt /app/requirements.txt
+# Path is relative to the build context (project root)
+COPY ./app/requirements.txt /app/requirements.txt
 
 # Install any needed packages specified in requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the application code into the container at /app
-COPY . /app
+# This copies the content of the 'app' directory from the build context (project root)
+# into the '/app' directory in the container (which is the WORKDIR).
+COPY ./app/ /app/
 
 # Expose port 8000 for Uvicorn
 EXPOSE 8000

--- a/scripts/Dockerfile.monitor
+++ b/scripts/Dockerfile.monitor
@@ -1,13 +1,15 @@
 FROM python:3.9-slim
 
-WORKDIR /monitor_app
+WORKDIR /monitor_app # Initial WORKDIR
 
 ENV PYTHONPATH "${PYTHONPATH}:/app_root"
 
-# Copy monitor script and its config, and common if needed by redis_client
-COPY ./scripts /app_root/scripts
-COPY ./common /app_root/common # If common.redis_client is used by monitor
+# Copy necessary application code from the build context (project root)
+# into the /app_root directory in the container.
+COPY ./scripts/ /app_root/scripts/
+COPY ./common/ /app_root/common/ # If common.redis_client is used by monitor
 
+# Set the final working directory
 WORKDIR /app_root/scripts
 
 # Install dependencies (just redis client, pydantic-settings for now)

--- a/workers/Dockerfile
+++ b/workers/Dockerfile
@@ -1,26 +1,23 @@
 # Use an official Python runtime as a parent image
 FROM python:3.9-slim
 
-# Set the working directory in the container
+# Set the working directory in the container (initial)
 WORKDIR /worker_app
 
-# Add project root to PYTHONPATH to allow imports like `from workers.config`
-# This assumes the Docker build context is the project root `bruteforce_framework/`
-# and we copy the 'workers' and 'common' directories.
+# Add project root to PYTHONPATH to allow imports from 'common' and 'workers' packages
 ENV PYTHONPATH "${PYTHONPATH}:/app_root"
 
-# Copy only necessary directories: 'workers' and 'common' (if it exists and is needed by worker)
-# We place them inside a directory called /app_root in the container.
-COPY ./workers /app_root/workers
-COPY ./common /app_root/common # Assuming 'common' might be used by worker later
+# Copy necessary application code from the build context (project root)
+# into the /app_root directory in the container.
+COPY ./workers/ /app_root/workers/
+COPY ./common/ /app_root/common/
 
-# Change working directory to where the worker code is, for convenience
+# Set the final working directory
 WORKDIR /app_root/workers
 
 # Install any needed packages specified in requirements_worker.txt
-# requirements_worker.txt is expected to be inside the 'workers' directory
+# (requirements_worker.txt is expected to be inside the 'workers' directory)
 RUN pip install --no-cache-dir -r requirements_worker.txt
-
 
 # Command to run the worker script
 # Using -u for unbuffered output, good for logging


### PR DESCRIPTION
This commit fixes errors in the Docker build process related to incorrect file paths in COPY commands within the Dockerfiles for the api_server, and monitor services.

Changes:
- In `app/Dockerfile`:
  - Changed `COPY ./requirements.txt` to `COPY ./app/requirements.txt`.
  - Changed `COPY . /app` to `COPY ./app/ /app/` to correctly copy only the app directory contents.
- In `workers/Dockerfile`:
  - Changed `COPY ./workers` to `COPY ./workers/`.
  - Changed `COPY ./common` to `COPY ./common/`.
- In `scripts/Dockerfile.monitor`:
  - Changed `COPY ./scripts` to `COPY ./scripts/`.
  - Changed `COPY ./common` to `COPY ./common/`.

These changes ensure that files and directories are copied correctly relative to the project root, which is the build context specified in `docker-compose.yml`.